### PR TITLE
Implement notification history feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ SRC_MODULES= \
 	src/advanced/intelligence/comments.c \
 	src/advanced/intelligence/indentation.c \
 	src/core/editor_context.c \
+	src/core/features/navigation_history.c \
 	src/core/editor_init.c \
 	src/core/editor_state.c \
 	src/core/editor_render.c \

--- a/src/advanced/lsp/lsp-features/lsp_goto.c
+++ b/src/advanced/lsp/lsp-features/lsp_goto.c
@@ -5,8 +5,11 @@
 #include "../../../terminal/windows/edw.h"
 #include "../../../terminal/windows/pow.h"
 #include "../lsp-features/lsp_completion.h"
+#include "../../../core/features/navigation_history.h"
 
 void jumpToLocation(ModuleContext* data, LSP_Location location) {
+  pushNavigationPoint(data->editor_context);
+
   openNewFile(location.file_name.file_name, data->files_state.files, data->files_state.size,
               data->files_state.current_file_index, &data->view_port.gui->ofw_context.refresh_ofw,
               data->files_state.refresh_local_vars);

--- a/src/advanced/lsp/lsp_dispatcher.h
+++ b/src/advanced/lsp/lsp_dispatcher.h
@@ -7,11 +7,14 @@
 #include "../../io-management/viewport_history.h"
 #include "../shared.h"
 
+struct EditorContext;
+
 typedef struct ModuleContext {
   FilesState files_state;
   ViewPort view_port;
   Cursor* cursor;
   PayloadStateChange *payload_state_change;
+  struct EditorContext* editor_context;
 } ModuleContext;
 
 

--- a/src/core/editor_context.h
+++ b/src/core/editor_context.h
@@ -7,6 +7,7 @@
 #include "../io-management/io_explorer.h"
 #include "../terminal/highlight.h"
 #include "../terminal/windows/edw.h"
+#include "features/navigation_history.h"
 
 typedef enum {
   EVENT_CONTINUE,
@@ -14,7 +15,7 @@ typedef enum {
   EVENT_READ_INPUT,
 } EventLoopAction;
 
-typedef struct {
+typedef struct EditorContext {
   FileContainer* files;
   int file_count;
   int current_file_index;
@@ -30,11 +31,11 @@ typedef struct {
   MEVENT m_event;
   int peek_c;
   bool mouse_drag;
-  time_val last_time_mouse_drag;
-  time_val t_date;
-  clock_t t_clock;
+
   bool quit_popup_active;
   bool force_quit;
+
+  NavigationHistory nav_history;
 } EditorContext;
 
 FileContainer* getActiveFile(EditorContext* ctx);

--- a/src/core/editor_destroy.c
+++ b/src/core/editor_destroy.c
@@ -40,6 +40,7 @@ static void finalizeWorkspace(EditorContext* ctx) {
     getWorkspaceSettingsForCurrentDir(&new_settings, ctx->files, ctx->file_count, ctx->current_file_index,
                                       ctx->gui_context.ofw_context.ofw_height != 0,
                                       ctx->gui_context.few_context.few_width != 0, FILE_EXPLORER_WIDTH);
+    saveNavigationHistoryToSettings(&new_settings, &ctx->nav_history);
     saveWorkspaceSettings(workspace_settings.dir_path, &new_settings);
     destroyWorkspaceSettings(&new_settings);
   }

--- a/src/core/editor_init.c
+++ b/src/core/editor_init.c
@@ -11,12 +11,10 @@ void initDefaultContext(int file_count, EditorContext* ctx) {
   ctx->refresh_local_vars = true;
   ctx->old_history_frame = NULL;
   ctx->mouse_drag = false;
-  ctx->last_time_mouse_drag = timeInMilliseconds();
-  ctx->t_date = timeInMilliseconds();
-  ctx->t_clock = clock();
   ctx->peek_c = -1;
   ctx->quit_popup_active = false;
   ctx->force_quit = false;
+  initNavigationHistory(&ctx->nav_history);
 }
 
 void setupFileExplorer(EditorContext* ctx) {

--- a/src/core/editor_input.c
+++ b/src/core/editor_input.c
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <ncurses.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 #include "../advanced/intelligence/auto_pairs.h"
@@ -22,13 +23,14 @@
 #include "../terminal/windows/few.h"
 #include "../terminal/windows/ofw.h"
 #include "../terminal/windows/popups/notification_popup.h"
-#include "../terminal/windows/popups/search_popup.h"
 #include "../terminal/windows/popups/quit_popup.h"
+#include "../terminal/windows/popups/search_popup.h"
 #include "../terminal/windows/pow.h"
 #include "../utils/clipboard_manager.h"
 #include "../utils/logger.h"
 #include "../utils/tools.h"
 #include "editor_lsp.h"
+#include "features/navigation_history.h"
 
 EventLoopAction dispatchInput(EditorContext* ctx, int key) {
   if (ctx->force_quit) {
@@ -40,29 +42,36 @@ EventLoopAction dispatchInput(EditorContext* ctx, int key) {
     return EVENT_READ_INPUT;
   }
 
-  EventLoopAction loopEnd = EVENT_READ_INPUT;
-  if (runInternalLogic(ctx, key, &loopEnd)) {
-    return loopEnd;
+  // navigation history setup
+  NavigationLocation prev_loc;
+  bool valid_prev = getActiveNavigationLocation(ctx, &prev_loc);
+
+
+
+
+  // Dispatcher pipeline fallback.
+  EventLoopAction ret_action = EVENT_READ_INPUT;
+
+  EventLoopAction tmp;
+  if (runInternalLogic(ctx, key, &tmp)) {
+    ret_action = tmp;
+  }
+  else if (handlePopupInput(ctx, key)) {
+    ret_action = ctx->force_quit ? EVENT_QUIT : EVENT_READ_INPUT;
+  }
+  else if (K_IS_SPECIAL(key)) {
+    ret_action = runSpecialKeyHandler(ctx, key);
+  }
+  else {
+    handleCharInsertion(ctx, key);
+    ret_action = EVENT_CONTINUE;
   }
 
-  if (handlePopupInput(ctx, key)) {
-    if (ctx->force_quit) {
-      return EVENT_QUIT;
-    }
-    return EVENT_READ_INPUT;
+  if (valid_prev) {
+    handleNavigationHistoryEvent(ctx, &prev_loc, key);
   }
 
-  /* Route all functional navigation, hotkeys, and releases to the command handler */
-  if (K_IS_SPECIAL(key)) {
-    return runSpecialKeyHandler(ctx, key);
-  }
-
-  /*
-   * Unified Routing:
-   * Any key NOT marked as Special is a printable character.
-   */
-  handleCharInsertion(ctx, key);
-  return EVENT_CONTINUE;
+  return ret_action;
 }
 
 
@@ -218,8 +227,6 @@ static void processMouseInput(EditorContext* ctx) {
               // Overwrite current m_event with the newly parsed mouse event
               ctx->m_event = tmp_event;
               detectComplexMouseEvents(&ctx->m_event);
-              ctx->t_date = timeInMilliseconds();
-              ctx->t_clock = clock();
 
               if (tmp_event.bstate == NO_EVENT_MOUSE) {
                 notifyUser(ctx, LOG_DEBUG, "Mouse event skipped !\n");
@@ -251,9 +258,6 @@ int readNextInput(EditorContext* ctx) {
   if (c == ERR) {
     return ERR;
   }
-
-  ctx->t_date = timeInMilliseconds();
-  ctx->t_clock = clock();
 
   int key = ERR;
 
@@ -514,6 +518,12 @@ EventLoopAction runSpecialKeyHandler(EditorContext* ctx, int key) {
       setDesiredColumn(*cursor, desired_column);
       gui_updateEDW(&ctx->gui_context);
       askCompletion(&ctx->gui_context, fc, true, false);
+      break;
+    case K_SPECIAL(K_MOD_CTRL, 'u'):
+      navigateBack(ctx);
+      break;
+    case K_SPECIAL(K_MOD_CTRL, 'p'):
+      navigateForward(ctx);
       break;
     case K_SPECIAL(K_MOD_CTRL, 'c'):
       saveToClipBoard(*cursor, *select_cursor);

--- a/src/core/editor_lsp.c
+++ b/src/core/editor_lsp.c
@@ -18,6 +18,7 @@ ModuleContext buildModuleContext(EditorContext* ctx) {
   payload.view_port = viewPortOf(&ctx->gui_context, &fc->screen_x, &fc->screen_y);
   payload.cursor = &fc->cursor;
   payload.payload_state_change = &ctx->payload_state_change;
+  payload.editor_context = ctx;
   return payload;
 }
 

--- a/src/core/features/navigation_history.c
+++ b/src/core/features/navigation_history.c
@@ -1,0 +1,376 @@
+#include "navigation_history.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../data-management/file_management.h"
+#include "../../io-management/workspace_settings.h"
+#include "../../terminal/key_management.h"
+#include "../../terminal/term_handler.h"
+#include "../../terminal/windows/edw.h"
+#include "../../utils/logger.h"
+#include "../editor_context.h"
+
+void initNavigationHistory(NavigationHistory* nh) {
+  nh->back_stack.size = 0;
+  nh->forward_stack.size = 0;
+  nh->in_typing_session = false;
+  nh->last_typing_time = 0;
+}
+
+bool getActiveNavigationLocation(struct EditorContext* ctx, NavigationLocation* loc) {
+  FileContainer* fc = getActiveFile(ctx);
+  if (!fc || fc->io_file.status == NONE) {
+    return false;
+  }
+  strncpy(loc->file_path, fc->io_file.path_abs, sizeof(loc->file_path) - 1);
+  loc->file_path[sizeof(loc->file_path) - 1] = '\0';
+  loc->row = cursor_row(fc->cursor);
+  loc->column = cursor_col(fc->cursor);
+  loc->screen_x = fc->screen_x;
+  loc->screen_y = fc->screen_y;
+  return true;
+}
+
+void pushNavigationPoint(struct EditorContext* ctx) {
+  NavigationLocation loc;
+  if (!getActiveNavigationLocation(ctx, &loc)) {
+    return;
+  }
+
+  // If we were in a typing session, finalize it
+  if (ctx->nav_history.in_typing_session) {
+    ctx->nav_history.in_typing_session = false;
+  }
+
+  NavigationStack* back = &ctx->nav_history.back_stack;
+
+  // Avoid pushing duplicate consecutive locations in back stack
+  if (back->size > 0) {
+    NavigationLocation top = back->items[back->size - 1];
+    if (strcmp(top.file_path, loc.file_path) == 0 && top.row == loc.row && top.column == loc.column) {
+      return;
+    }
+  }
+
+  if (back->size < MAX_NAV_HISTORY) {
+    back->items[back->size++] = loc;
+  }
+  else {
+    // Shift left to discard oldest
+    for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+      back->items[i - 1] = back->items[i];
+    }
+    back->items[MAX_NAV_HISTORY - 1] = loc;
+  }
+
+  // Clear forward stack on new navigation/jump
+  ctx->nav_history.forward_stack.size = 0;
+}
+
+static void perform_navigation_jump(struct EditorContext* ctx, NavigationLocation target) {
+  // Check if file is already open
+  int found_idx = -1;
+  for (int i = 0; i < ctx->file_count; i++) {
+    if (ctx->files[i].io_file.status != NONE && strcmp(ctx->files[i].io_file.path_abs, target.file_path) == 0) {
+      found_idx = i;
+      break;
+    }
+  }
+
+  if (found_idx != -1) {
+    ctx->current_file_index = found_idx;
+  }
+  else {
+    // Reopen the file
+    openNewFile(target.file_path, &ctx->files, &ctx->file_count, &ctx->current_file_index,
+                &ctx->gui_context.ofw_context.refresh_ofw, &ctx->refresh_local_vars);
+  }
+
+  FileContainer* fc = getActiveFile(ctx);
+  if (!fc) {
+    return;
+  }
+
+  // Restore cursor and view position
+  fc->cursor = tryToReachAbsPosition(fc->cursor, target.row, target.column);
+  fc->desired_column = target.column;
+  fc->screen_x = target.screen_x;
+  fc->screen_y = target.screen_y;
+
+  ctx->refresh_local_vars = true;
+  gui_updateOFW(&ctx->gui_context);
+  gui_updateEDW(&ctx->gui_context);
+  gui_closePopup(&ctx->gui_context);
+}
+
+void navigateBack(struct EditorContext* ctx) {
+  // If we are in a typing session, finalize it before navigating back
+  if (ctx->nav_history.in_typing_session) {
+    ctx->nav_history.in_typing_session = false;
+  }
+
+  NavigationStack* back = &ctx->nav_history.back_stack;
+  if (back->size == 0) {
+    return;
+  }
+
+  NavigationLocation current_loc;
+  if (!getActiveNavigationLocation(ctx, &current_loc)) {
+    return;
+  }
+
+  // Pop target location from back stack
+  NavigationLocation target_loc = back->items[--back->size];
+
+  // Push current location to forward stack
+  NavigationStack* forward = &ctx->nav_history.forward_stack;
+  if (forward->size < MAX_NAV_HISTORY) {
+    forward->items[forward->size++] = current_loc;
+  }
+  else {
+    for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+      forward->items[i - 1] = forward->items[i];
+    }
+    forward->items[MAX_NAV_HISTORY - 1] = current_loc;
+  }
+
+  perform_navigation_jump(ctx, target_loc);
+}
+
+void navigateForward(struct EditorContext* ctx) {
+  // If we are in a typing session, finalize it before navigating forward
+  if (ctx->nav_history.in_typing_session) {
+    ctx->nav_history.in_typing_session = false;
+  }
+
+  NavigationStack* forward = &ctx->nav_history.forward_stack;
+  if (forward->size == 0) {
+    return;
+  }
+
+  NavigationLocation current_loc;
+  if (!getActiveNavigationLocation(ctx, &current_loc)) {
+    return;
+  }
+
+  // Pop target location from forward stack
+  NavigationLocation target_loc = forward->items[--forward->size];
+
+  // Push current location to back stack
+  NavigationStack* back = &ctx->nav_history.back_stack;
+  if (back->size < MAX_NAV_HISTORY) {
+    back->items[back->size++] = current_loc;
+  }
+  else {
+    for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+      back->items[i - 1] = back->items[i];
+    }
+    back->items[MAX_NAV_HISTORY - 1] = current_loc;
+  }
+
+  perform_navigation_jump(ctx, target_loc);
+}
+
+static bool is_edit_key(int key) {
+  if (!K_IS_SPECIAL(key)) {
+    return true; // Any printable character
+  }
+  int code = K_CODE(key);
+  int mods = key & (K_MOD_SHIFT | K_MOD_ALT | K_MOD_CTRL | K_MOD_SUPER);
+
+  if (key == H_KEY_ENTER || key == H_KEY_SHIFT_ENTER || key == H_KEY_BACKSPACE || key == H_KEY_CTRL_DELETE ||
+      key == H_KEY_SUPPR || key == H_KEY_CTRL_SUPPR || key == H_KEY_TAB || key == H_KEY_SHIFT_TAB) {
+    return true;
+  }
+
+  // Ctrl+V (paste), Ctrl+X (cut), Ctrl+Z (undo), Ctrl+Y (redo), Ctrl+_ (comment)
+  if (mods == K_MOD_CTRL) {
+    if (code == 'v' || code == 'x' || code == 'z' || code == 'y' || code == '_') {
+      return true;
+    }
+  }
+  // Ctrl+Shift+: (comment)
+  if (mods == (K_MOD_CTRL | K_MOD_SHIFT) && code == ':') {
+    return true;
+  }
+
+  return false;
+}
+
+static bool is_significant_distance(NavigationLocation loc1, NavigationLocation loc2) {
+  if (strcmp(loc1.file_path, loc2.file_path) != 0) {
+    return true;
+  }
+  if (abs(loc1.row - loc2.row) > 1) {
+    return true;
+  }
+  if (abs(loc1.column - loc2.column) > 10) {
+    return true;
+  }
+  return false;
+}
+
+void handleNavigationHistoryEvent(struct EditorContext* ctx, const NavigationLocation* prev_loc, int key) {
+  if (!prev_loc) {
+    return;
+  }
+
+  if (key == K_SPECIAL(K_MOD_CTRL, 'u') || key == K_SPECIAL(K_MOD_CTRL, 'p')) {
+    return;
+  }
+
+  NavigationLocation curr_loc;
+  if (!getActiveNavigationLocation(ctx, &curr_loc)) {
+    return;
+  }
+
+  // 1. Check if we switched files
+  if (strcmp(prev_loc->file_path, curr_loc.file_path) != 0) {
+    if (ctx->nav_history.in_typing_session) {
+      ctx->nav_history.in_typing_session = false;
+    }
+
+    NavigationStack* back = &ctx->nav_history.back_stack;
+    if (back->size == 0 || strcmp(back->items[back->size - 1].file_path, prev_loc->file_path) != 0 ||
+        back->items[back->size - 1].row != prev_loc->row || back->items[back->size - 1].column != prev_loc->column) {
+
+      if (back->size < MAX_NAV_HISTORY) {
+        back->items[back->size++] = *prev_loc;
+      }
+      else {
+        for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+          back->items[i - 1] = back->items[i];
+        }
+        back->items[MAX_NAV_HISTORY - 1] = *prev_loc;
+      }
+      notifyUser(ctx, LOG_INFO, "handle_navigation_history_event: pushed file switch from %s to %s, back size=%d",
+                 prev_loc->file_path, curr_loc.file_path, back->size);
+      ctx->nav_history.forward_stack.size = 0;
+    }
+    return;
+  }
+
+  // 2. Same file. Check if an edit key was pressed.
+  bool is_edit = is_edit_key(key);
+
+  if (is_edit) {
+    time_val now = timeInMilliseconds();
+
+    if (!ctx->nav_history.in_typing_session) {
+      // Start typing session
+      ctx->nav_history.in_typing_session = true;
+      ctx->nav_history.last_typing_time = now;
+      ctx->nav_history.typing_start_location = *prev_loc;
+
+      // Push typing start point to back stack
+      NavigationLocation loc = ctx->nav_history.typing_start_location;
+      NavigationStack* back = &ctx->nav_history.back_stack;
+      if (back->size == 0 || strcmp(back->items[back->size - 1].file_path, loc.file_path) != 0 ||
+          back->items[back->size - 1].row != loc.row || back->items[back->size - 1].column != loc.column) {
+
+        if (back->size < MAX_NAV_HISTORY) {
+          back->items[back->size++] = loc;
+        }
+        else {
+          for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+            back->items[i - 1] = back->items[i];
+          }
+          back->items[MAX_NAV_HISTORY - 1] = loc;
+        }
+        ctx->nav_history.forward_stack.size = 0;
+      }
+    }
+    else {
+      // Continue typing session. Check time gap
+      if (diff2Time(now, ctx->nav_history.last_typing_time) > 3000) {
+        // Finalize old session and push end location if significant
+        if (is_significant_distance(ctx->nav_history.typing_start_location, *prev_loc)) {
+          NavigationStack* back = &ctx->nav_history.back_stack;
+          if (back->size < MAX_NAV_HISTORY) {
+            back->items[back->size++] = *prev_loc;
+          }
+          else {
+            for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+              back->items[i - 1] = back->items[i];
+            }
+            back->items[MAX_NAV_HISTORY - 1] = *prev_loc;
+          }
+        }
+
+        // Start new session
+        ctx->nav_history.typing_start_location = *prev_loc;
+
+        NavigationLocation loc = ctx->nav_history.typing_start_location;
+        NavigationStack* back = &ctx->nav_history.back_stack;
+        if (back->size < MAX_NAV_HISTORY) {
+          back->items[back->size++] = loc;
+        }
+        else {
+          for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+            back->items[i - 1] = back->items[i];
+          }
+          back->items[MAX_NAV_HISTORY - 1] = loc;
+        }
+      }
+      ctx->nav_history.last_typing_time = now;
+    }
+  }
+  else {
+    // Non-edit action. If we were typing, check if the cursor moved to finalize
+    if (ctx->nav_history.in_typing_session) {
+      if (prev_loc->row != curr_loc.row || prev_loc->column != curr_loc.column) {
+        ctx->nav_history.in_typing_session = false;
+
+        if (is_significant_distance(ctx->nav_history.typing_start_location, *prev_loc)) {
+          NavigationStack* back = &ctx->nav_history.back_stack;
+          if (back->size < MAX_NAV_HISTORY) {
+            back->items[back->size++] = *prev_loc;
+          }
+          else {
+            for (int i = 1; i < MAX_NAV_HISTORY; i++) {
+              back->items[i - 1] = back->items[i];
+            }
+            back->items[MAX_NAV_HISTORY - 1] = *prev_loc;
+          }
+        }
+      }
+    }
+  }
+}
+
+void restoreNavigationHistory(NavigationHistory* nh, struct WorkspaceSettings* settings) {
+  nh->back_stack.size = settings->nav_back_size;
+  for (int i = 0; i < settings->nav_back_size; i++) {
+    nh->back_stack.items[i] = settings->nav_back_items[i];
+  }
+
+  nh->forward_stack.size = settings->nav_forward_size;
+  for (int i = 0; i < settings->nav_forward_size; i++) {
+    nh->forward_stack.items[i] = settings->nav_forward_items[i];
+  }
+}
+
+void saveNavigationHistoryToSettings(struct WorkspaceSettings* settings, NavigationHistory* nh) {
+  settings->nav_back_size = nh->back_stack.size;
+  if (nh->back_stack.size > 0) {
+    settings->nav_back_items = malloc(nh->back_stack.size * sizeof(NavigationLocation));
+    for (int i = 0; i < nh->back_stack.size; i++) {
+      settings->nav_back_items[i] = nh->back_stack.items[i];
+    }
+  }
+  else {
+    settings->nav_back_items = NULL;
+  }
+
+  settings->nav_forward_size = nh->forward_stack.size;
+  if (nh->forward_stack.size > 0) {
+    settings->nav_forward_items = malloc(nh->forward_stack.size * sizeof(NavigationLocation));
+    for (int i = 0; i < nh->forward_stack.size; i++) {
+      settings->nav_forward_items[i] = nh->forward_stack.items[i];
+    }
+  }
+  else {
+    settings->nav_forward_items = NULL;
+  }
+}

--- a/src/core/features/navigation_history.h
+++ b/src/core/features/navigation_history.h
@@ -1,0 +1,45 @@
+#ifndef NAVIGATION_HISTORY_H
+#define NAVIGATION_HISTORY_H
+
+#include <stdbool.h>
+
+#include "../../utils/tools.h"
+
+#define MAX_NAV_HISTORY 100
+
+typedef struct {
+  char file_path[4096];
+  int row;
+  int column;
+  int screen_x;
+  int screen_y;
+} NavigationLocation;
+
+typedef struct {
+  NavigationLocation items[MAX_NAV_HISTORY];
+  int size;
+} NavigationStack;
+
+typedef struct {
+  NavigationStack back_stack;
+  NavigationStack forward_stack;
+
+  bool in_typing_session;
+  NavigationLocation typing_start_location;
+  time_val last_typing_time;
+} NavigationHistory;
+
+struct EditorContext;
+
+void initNavigationHistory(NavigationHistory* nh);
+bool getActiveNavigationLocation(struct EditorContext* ctx, NavigationLocation* loc);
+void pushNavigationPoint(struct EditorContext* ctx);
+void navigateBack(struct EditorContext* ctx);
+void navigateForward(struct EditorContext* ctx);
+void handleNavigationHistoryEvent(struct EditorContext* ctx, const NavigationLocation* prev_loc, int key);
+
+struct WorkspaceSettings;
+void restoreNavigationHistory(NavigationHistory* nh, struct WorkspaceSettings* settings);
+void saveNavigationHistoryToSettings(struct WorkspaceSettings* settings, NavigationHistory* nh);
+
+#endif // NAVIGATION_HISTORY_H

--- a/src/io-management/workspace_settings.c
+++ b/src/io-management/workspace_settings.c
@@ -24,6 +24,11 @@ void getWorkspaceSettingsForCurrentDir(WorkspaceSettings* settings, FileContaine
   settings->file_explorer_size = file_explorer_size;
   settings->showing_file_explorer_window = showing_file_explorer_window;
   settings->showing_opened_file_window = showing_opened_file_window;
+
+  settings->nav_back_size = 0;
+  settings->nav_back_items = NULL;
+  settings->nav_forward_size = 0;
+  settings->nav_forward_items = NULL;
 }
 
 void destroyWorkspaceSettings(WorkspaceSettings* settings) {
@@ -31,6 +36,13 @@ void destroyWorkspaceSettings(WorkspaceSettings* settings) {
     free(settings->files[i]);
   }
   free(settings->files);
+
+  if (settings->nav_back_items != NULL) {
+    free(settings->nav_back_items);
+  }
+  if (settings->nav_forward_items != NULL) {
+    free(settings->nav_forward_items);
+  }
 }
 
 void touchDirSettingsFolder() {
@@ -100,6 +112,10 @@ bool loadWorkspaceSettings(char* dir_path, WorkspaceSettings* settings) {
     settings->showing_file_explorer_window = false;
     settings->showing_opened_file_window = false;
     settings->file_explorer_size = 0;
+    settings->nav_back_size = 0;
+    settings->nav_back_items = NULL;
+    settings->nav_forward_size = 0;
+    settings->nav_forward_items = NULL;
     // fprintf(stderr, "Unable to load dir settings.\r\n");
     return false;
   }
@@ -137,6 +153,28 @@ cJSON* WorkspaceSettingsToJSON(WorkspaceSettings* settings) {
   cJSON_AddBoolToObject(json_settings, "showing_file_explorer_window", settings->showing_file_explorer_window);
   cJSON_AddNumberToObject(json_settings, "file_explorer_size", settings->file_explorer_size);
 
+  cJSON* nav_back_array = cJSON_AddArrayToObject(json_settings, "nav_back");
+  for (int i = 0; i < settings->nav_back_size; i++) {
+    cJSON* loc_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(loc_json, "file_path", settings->nav_back_items[i].file_path);
+    cJSON_AddNumberToObject(loc_json, "row", settings->nav_back_items[i].row);
+    cJSON_AddNumberToObject(loc_json, "column", settings->nav_back_items[i].column);
+    cJSON_AddNumberToObject(loc_json, "screen_x", settings->nav_back_items[i].screen_x);
+    cJSON_AddNumberToObject(loc_json, "screen_y", settings->nav_back_items[i].screen_y);
+    cJSON_AddItemToArray(nav_back_array, loc_json);
+  }
+
+  cJSON* nav_forward_array = cJSON_AddArrayToObject(json_settings, "nav_forward");
+  for (int i = 0; i < settings->nav_forward_size; i++) {
+    cJSON* loc_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(loc_json, "file_path", settings->nav_forward_items[i].file_path);
+    cJSON_AddNumberToObject(loc_json, "row", settings->nav_forward_items[i].row);
+    cJSON_AddNumberToObject(loc_json, "column", settings->nav_forward_items[i].column);
+    cJSON_AddNumberToObject(loc_json, "screen_x", settings->nav_forward_items[i].screen_x);
+    cJSON_AddNumberToObject(loc_json, "screen_y", settings->nav_forward_items[i].screen_y);
+    cJSON_AddItemToArray(nav_forward_array, loc_json);
+  }
+
   return json_settings;
 }
 
@@ -157,6 +195,78 @@ void JSONToWorkspaceSettings(WorkspaceSettings* settings, cJSON* json) {
   settings->showing_opened_file_window = cJSON_IsTrue(cJSON_GetObjectItem(json, "showing_opened_file_window"));
   settings->showing_file_explorer_window = cJSON_IsTrue(cJSON_GetObjectItem(json, "showing_file_explorer_window"));
   settings->file_explorer_size = cJSON_GetNumberValue(cJSON_GetObjectItem(json, "file_explorer_size"));
+
+  cJSON* nav_back_array = cJSON_GetObjectItem(json, "nav_back");
+  if (cJSON_IsArray(nav_back_array)) {
+    settings->nav_back_size = cJSON_GetArraySize(nav_back_array);
+    if (settings->nav_back_size > 0) {
+      settings->nav_back_items = malloc(settings->nav_back_size * sizeof(NavigationLocation));
+      for (int i = 0; i < settings->nav_back_size; i++) {
+        cJSON* item = cJSON_GetArrayItem(nav_back_array, i);
+        cJSON* file_path = cJSON_GetObjectItem(item, "file_path");
+        cJSON* row = cJSON_GetObjectItem(item, "row");
+        cJSON* column = cJSON_GetObjectItem(item, "column");
+        cJSON* screen_x = cJSON_GetObjectItem(item, "screen_x");
+        cJSON* screen_y = cJSON_GetObjectItem(item, "screen_y");
+
+        if (cJSON_IsString(file_path)) {
+          strncpy(settings->nav_back_items[i].file_path, cJSON_GetStringValue(file_path),
+                  sizeof(settings->nav_back_items[i].file_path) - 1);
+          settings->nav_back_items[i].file_path[sizeof(settings->nav_back_items[i].file_path) - 1] = '\0';
+        }
+        else {
+          settings->nav_back_items[i].file_path[0] = '\0';
+        }
+        settings->nav_back_items[i].row = cJSON_IsNumber(row) ? (int)cJSON_GetNumberValue(row) : 0;
+        settings->nav_back_items[i].column = cJSON_IsNumber(column) ? (int)cJSON_GetNumberValue(column) : 0;
+        settings->nav_back_items[i].screen_x = cJSON_IsNumber(screen_x) ? (int)cJSON_GetNumberValue(screen_x) : 0;
+        settings->nav_back_items[i].screen_y = cJSON_IsNumber(screen_y) ? (int)cJSON_GetNumberValue(screen_y) : 0;
+      }
+    }
+    else {
+      settings->nav_back_items = NULL;
+    }
+  }
+  else {
+    settings->nav_back_size = 0;
+    settings->nav_back_items = NULL;
+  }
+
+  cJSON* nav_forward_array = cJSON_GetObjectItem(json, "nav_forward");
+  if (cJSON_IsArray(nav_forward_array)) {
+    settings->nav_forward_size = cJSON_GetArraySize(nav_forward_array);
+    if (settings->nav_forward_size > 0) {
+      settings->nav_forward_items = malloc(settings->nav_forward_size * sizeof(NavigationLocation));
+      for (int i = 0; i < settings->nav_forward_size; i++) {
+        cJSON* item = cJSON_GetArrayItem(nav_forward_array, i);
+        cJSON* file_path = cJSON_GetObjectItem(item, "file_path");
+        cJSON* row = cJSON_GetObjectItem(item, "row");
+        cJSON* column = cJSON_GetObjectItem(item, "column");
+        cJSON* screen_x = cJSON_GetObjectItem(item, "screen_x");
+        cJSON* screen_y = cJSON_GetObjectItem(item, "screen_y");
+
+        if (cJSON_IsString(file_path)) {
+          strncpy(settings->nav_forward_items[i].file_path, cJSON_GetStringValue(file_path),
+                  sizeof(settings->nav_forward_items[i].file_path) - 1);
+          settings->nav_forward_items[i].file_path[sizeof(settings->nav_forward_items[i].file_path) - 1] = '\0';
+        }
+        else {
+          settings->nav_forward_items[i].file_path[0] = '\0';
+        }
+        settings->nav_forward_items[i].row = cJSON_IsNumber(row) ? (int)cJSON_GetNumberValue(row) : 0;
+        settings->nav_forward_items[i].column = cJSON_IsNumber(column) ? (int)cJSON_GetNumberValue(column) : 0;
+        settings->nav_forward_items[i].screen_x = cJSON_IsNumber(screen_x) ? (int)cJSON_GetNumberValue(screen_x) : 0;
+        settings->nav_forward_items[i].screen_y = cJSON_IsNumber(screen_y) ? (int)cJSON_GetNumberValue(screen_y) : 0;
+      }
+    }
+    else {
+      settings->nav_forward_items = NULL;
+    }
+  }
+  else {
+    settings->nav_forward_size = 0;
+    settings->nav_forward_items = NULL;
+  }
 }
 
 void setupWorkspace(WorkspaceSettings* loaded_settings, int* file_count, char*** file_names, gui_Context* gui_context,

--- a/src/io-management/workspace_settings.h
+++ b/src/io-management/workspace_settings.h
@@ -3,12 +3,14 @@
 #include <stdbool.h>
 
 #include "../../lib/cJSON/cJSON.h"
+#include "../core/features/navigation_history.h"
 #include "../data-management/file_management.h"
 #include "../terminal/term_handler.h"
 
+
 #define FOLDER_DIR_SETTINGS_NAME ".workspace_settings"
 
-typedef struct {
+typedef struct WorkspaceSettings {
   // Is used
   bool is_used;
 
@@ -24,6 +26,12 @@ typedef struct {
 
   // Dir path
   char* dir_path;
+
+  // Navigation History
+  int nav_back_size;
+  NavigationLocation* nav_back_items;
+  int nav_forward_size;
+  NavigationLocation* nav_forward_items;
 } WorkspaceSettings;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -61,6 +61,9 @@ int main(int file_count, char** args) {
 
   /// --- Setup Workspace Settings ---
   setupWorkspace(&workspace_settings, &ctx.file_count, &file_names, &ctx.gui_context, &ctx.current_file_index);
+  if (workspace_settings.is_used) {
+    restoreNavigationHistory(&ctx.nav_history, &workspace_settings);
+  }
 
   /// --- Setup Opened Files ---
   setupOpenedFiles(&ctx.file_count, file_names, &ctx.files);

--- a/src/terminal/click_handler.c
+++ b/src/terminal/click_handler.c
@@ -15,6 +15,10 @@
 #include "windows/few.h"
 #include "windows/popups/language_popup.h"
 #include "windows/pow.h"
+#include "../core/features/navigation_history.h"
+
+static int find_clicked_tab_index(gui_Context* gui, FileContainer* files, int file_count, int current_file,
+                                  const MEVENT* m);
 
 /* -------------------------------------------------------------------------- */
 /*                                Mouse Helpers                               */


### PR DESCRIPTION
*Generated by Github Copilot*

# Add Navigation History Feature

## Overview
This PR implements a complete **navigation history system** for the Alwide TUI IDE, enabling users to navigate backward and forward through their cursor positions and file switches—similar to browser back/forward navigation.

## What's New

### Core Features

- **Back Navigation (Ctrl+U)**: Jump back to previous cursor positions and files
- **Forward Navigation (Ctrl+P)**: Jump forward after navigating back
- **Automatic Position Tracking**: 
  - Records cursor positions during normal editing
  - Tracks file switches
  - Detects editing sessions with time-based grouping (3-second threshold)
- **Session Persistence**: Navigation history is saved to workspace settings and restored on startup

**New Files:**
- `src/core/features/navigation_history.h` — Type definitions and API
- `src/core/features/navigation_history.c` — Core implementation (376 lines)

