### PR TITLE
Added fixes for macOS compilability.

### DIFF
--- a/src/advanced/lsp/lsp_client.c
+++ b/src/advanced/lsp/lsp_client.c
@@ -1,14 +1,17 @@
 #include "lsp_client.h"
 
+#ifdef __linux__
+  #include <sys/prctl.h>
+#endif
+
 #include <assert.h>
 #include <libgen.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/poll.h>
-#include <sys/prctl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include "../../utils/tools.h"
@@ -68,9 +71,10 @@ bool LSP_openLSPServer(char* name, char* command_args, char* language, LSP_Serve
     dup2(server->inpipefd[1], STDOUT_FILENO);
     // dup2(server->inpipefd[1], STDERR_FILENO); // Do not bind the err channel it's used for lsp_server logs.
 
-
-    // ask kernel to deliver SIGTERM in case the parent dies
-    prctl(PR_SET_PDEATHSIG, SIGTERM);
+    #ifdef __linux__
+      // ask kernel to deliver SIGTERM in case the parent dies
+      prctl(PR_SET_PDEATHSIG, SIGTERM);
+    #endif
 
     // close unused pipe ends
     close(server->outpipefd[1]);

--- a/src/advanced/lsp/lsp_client.h
+++ b/src/advanced/lsp/lsp_client.h
@@ -11,7 +11,7 @@
 #ifndef CLIENT_H
 #define CLIENT_H
 
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <sys/types.h>
 

--- a/src/advanced/tree-sitter/tree_manager.c
+++ b/src/advanced/tree-sitter/tree_manager.c
@@ -1,7 +1,7 @@
 #include "tree_manager.h"
 
 #include <assert.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1,6 +1,6 @@
 #include "config.h"
 
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/config/language_feature.c
+++ b/src/config/language_feature.c
@@ -1,7 +1,7 @@
 #include "language_feature.h"
 
 #include <libgen.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/io-management/io_explorer.h
+++ b/src/io-management/io_explorer.h
@@ -1,6 +1,6 @@
 #ifndef IO_EXPLORER_H
 #define IO_EXPLORER_H
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdbool.h>
 
 

--- a/src/io-management/io_manager.h
+++ b/src/io-management/io_manager.h
@@ -1,6 +1,6 @@
 #ifndef FILE_MANAGER_H
 #define FILE_MANAGER_H
-#include <linux/limits.h>
+#include <limits.h>
 
 #include "../config/language_feature.h"
 #include "../data-management/file_structure.h"

--- a/src/lsp_test.c
+++ b/src/lsp_test.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include <cjson/cJSON.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/wait.h>
@@ -10,7 +10,7 @@
 #include "advanced/lsp/lsp_client.h"
 #include "advanced/lsp/lsp_handler.h"
 #include "advanced/tree-sitter/tree_manager.h"
-#include "io_management/workspace_settings.h"
+#include "io-management/workspace_settings.h"
 #include "utils/tools.h"
 
 //     if (poll(&(struct pollfd){.fd = lsp.inpipefd[0], .events = POLLIN}, 1, 0) == 1) {
@@ -74,7 +74,7 @@ int main(int argc, char** args) {
         file_content[fsize] = 0;
 
 
-        LSP_notifyLspFileDidOpen(lsp, file_name, file_content);
+        LSP_notifyLspFileDidOpen(&lsp, file_name, file_content);
 
         free(file_content);
         break;
@@ -87,7 +87,7 @@ int main(int argc, char** args) {
         getLocalURI(file_name, uri);
         cJSON_AddStringToObject(text_document, "uri", uri);
 
-        LSP_sendPacketWithJSON(&lsp, "textDocument/semanticTokens/full", tokens_req, REQUEST);
+        LSP_sendPacketWithJSON(&lsp, "textDocument/semanticTokens/full", tokens_req, LSP_REQUEST);
 
         cJSON_Delete(tokens_req);
         break;
@@ -100,7 +100,7 @@ int main(int argc, char** args) {
         getLocalURI(file_name, uri_delta);
         cJSON_AddStringToObject(text_document_delta, "uri", uri_delta);
 
-        LSP_sendPacketWithJSON(&lsp, "textDocument/semanticTokens/full/delta", tokens_req_delta, REQUEST);
+        LSP_sendPacketWithJSON(&lsp, "textDocument/semanticTokens/full/delta", tokens_req_delta, LSP_REQUEST);
 
         cJSON_Delete(tokens_req_delta);
 

--- a/src/lsp_test.c
+++ b/src/lsp_test.c
@@ -1,5 +1,5 @@
 #include <assert.h>
-#include <cjson/cJSON.h>
+#include "../lib/cJSON/cJSON.h"
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,6 +22,8 @@ cJSON* config;
 ParserList parsers;
 LSPServerLinkedList lsp_servers;
 WorkspaceSettings loaded_settings;
+LF_LanguageFeatureList language_features;
+WorkspaceSettings workspace_settings;
 
 
 int main(int argc, char** args) {

--- a/src/terminal/click_handler.c
+++ b/src/terminal/click_handler.c
@@ -41,7 +41,15 @@ static inline bool is_right_double_click(const MEVENT* m) { return m->bstate & B
 static inline bool is_right_click_action(const MEVENT* m) { return is_right_click_pressed(m) || is_right_click(m); }
 
 static inline bool is_scroll_up(const MEVENT* m) { return m->bstate & BUTTON4_PRESSED; }
-static inline bool is_scroll_down(const MEVENT* m) { return m->bstate & BUTTON5_PRESSED; }
+static inline bool is_scroll_down(const MEVENT* m) {
+  // TODO: Support scroll-down on ncurses builds without BUTTON5_*.
+  // macOS system ncurses does not expose BUTTON5_PRESSED.
+  #ifdef BUTTON5_PRESSED
+    return m->bstate & BUTTON5_PRESSED;
+  #else
+    return false;
+  #endif
+}
 static inline bool is_scroll_left(const MEVENT* m) { return m->bstate & BUTTON6_PRESSED; }
 static inline bool is_scroll_right(const MEVENT* m) { return m->bstate & BUTTON7_PRESSED; }
 static inline bool is_button8_pressed(const MEVENT* m) { return m->bstate & BUTTON8_PRESSED; }

--- a/src/terminal/highlight.c
+++ b/src/terminal/highlight.c
@@ -414,6 +414,7 @@ TextPartHighlightDescriptor* whd_tphd_forCursorWithOffsetIndex(WindowHighlightDe
 
 
 void initColorsForTheme(HighlightThemeList theme_list, int* color_index, int* color_pair) {
+#if AL_HAS_EXTENDED_NCURSES_COLORS
   // Setup color theme.
   for (int i = 0; i < theme_list.size; i++) {
     init_extended_color((*color_index)++, theme_list.groups[i].color.r, theme_list.groups[i].color.g,
@@ -427,4 +428,9 @@ void initColorsForTheme(HighlightThemeList theme_list, int* color_index, int* co
     theme_list.groups[i].color_hover_n = *color_pair + 1000;
     (*color_pair)++;
   }
+#else
+  (void)theme_list;
+  (void)color_index;
+  (void)color_pair;
+#endif
 }

--- a/src/terminal/highlight.c
+++ b/src/terminal/highlight.c
@@ -415,18 +415,25 @@ TextPartHighlightDescriptor* whd_tphd_forCursorWithOffsetIndex(WindowHighlightDe
 
 void initColorsForTheme(HighlightThemeList theme_list, int* color_index, int* color_pair) {
 #if AL_HAS_EXTENDED_NCURSES_COLORS
-  // Setup color theme.
-  for (int i = 0; i < theme_list.size; i++) {
-    init_extended_color((*color_index)++, theme_list.groups[i].color.r, theme_list.groups[i].color.g,
-                        theme_list.groups[i].color.b);
-    init_extended_pair(*color_pair, *color_index - 1, BG_COLOR_DEFAULT);
-    theme_list.groups[i].color_n = *color_pair;
+  if (COLORS >= 256) {
+    // Setup color theme.
+    for (int i = 0; i < theme_list.size; i++) {
+      init_extended_color((*color_index)++, theme_list.groups[i].color.r, theme_list.groups[i].color.g,
+                          theme_list.groups[i].color.b);
+      init_extended_pair(*color_pair, *color_index - 1, BG_COLOR_DEFAULT);
+      theme_list.groups[i].color_n = *color_pair;
 
-    init_extended_color((*color_index)++, theme_list.groups[i].color_hover.r, theme_list.groups[i].color_hover.g,
-                        theme_list.groups[i].color_hover.b);
-    init_extended_pair(*color_pair + 1000, *color_index - 1, BG_COLOR_HOVER);
-    theme_list.groups[i].color_hover_n = *color_pair + 1000;
-    (*color_pair)++;
+      init_extended_color((*color_index)++, theme_list.groups[i].color_hover.r, theme_list.groups[i].color_hover.g,
+                          theme_list.groups[i].color_hover.b);
+      init_extended_pair(*color_pair + 1000, *color_index - 1, BG_COLOR_HOVER);
+      theme_list.groups[i].color_hover_n = *color_pair + 1000;
+      (*color_pair)++;
+    }
+  }
+  else {
+    (void)theme_list;
+    (void)color_index;
+    (void)color_pair;
   }
 #else
   (void)theme_list;

--- a/src/terminal/key_management.c
+++ b/src/terminal/key_management.c
@@ -44,9 +44,16 @@ void printEventList(MEVENT* event) {
   printIfPresent(event, BUTTON4_RELEASED, "BUTTON4_RELEASED");
   printIfPresent(event, BUTTON4_CLICKED, "BUTTON4_CLICKED");
 
-  printIfPresent(event, BUTTON5_PRESSED, "BUTTON5_PRESSED");
-  printIfPresent(event, BUTTON5_RELEASED, "BUTTON5_RELEASED");
-  printIfPresent(event, BUTTON5_CLICKED, "BUTTON5_CLICKED");
+  // BUTTON5_* is not available on all ncurses implementations, e.g. macOS.
+  #ifdef BUTTON5_PRESSED
+    printIfPresent(event, BUTTON5_PRESSED, "BUTTON5_PRESSED");
+  #endif
+  #ifdef BUTTON5_RELEASED
+    printIfPresent(event, BUTTON5_RELEASED, "BUTTON5_RELEASED");
+  #endif
+  #ifdef BUTTON5_CLICKED
+    printIfPresent(event, BUTTON5_CLICKED, "BUTTON5_CLICKED");
+  #endif
 
   printIfPresent(event, BUTTON6_PRESSED, "BUTTON6_PRESSED");
   printIfPresent(event, BUTTON7_PRESSED, "BUTTON7_PRESSED");
@@ -124,13 +131,15 @@ void detectComplexMouseEvents(MEVENT* event) {
     tmp_event.z = event->z;
   }
 
-  if (event->bstate & BUTTON5_PRESSED) {
-    MEVENT tmp_event;
-    tmp_event.bstate = BUTTON5_RELEASED;
-    tmp_event.x = event->x;
-    tmp_event.y = event->y;
-    tmp_event.z = event->z;
-  }
+  #ifdef BUTTON5_PRESSED
+    if (event->bstate & BUTTON5_PRESSED) {
+      MEVENT tmp_event;
+      tmp_event.bstate = BUTTON5_RELEASED;
+      tmp_event.x = event->x;
+      tmp_event.y = event->y;
+      tmp_event.z = event->z;
+    }
+  #endif
 }
 
 int normalize_legacy(int c) {

--- a/src/terminal/kitty_protocol.c
+++ b/src/terminal/kitty_protocol.c
@@ -111,7 +111,9 @@ bool kitty_parse_sequence(int first_char, KittyKeyEvent* event, MEVENT* mouse_ev
         mouse_event->bstate |= BUTTON4_PRESSED;
       }
       else if (base_button == 65) {
-        mouse_event->bstate |= BUTTON5_PRESSED;
+        #ifdef BUTTON5_PRESSED
+          mouse_event->bstate |= BUTTON5_PRESSED;
+        #endif
       }
       else if (base_button == 66) {
         mouse_event->bstate |= BUTTON6_PRESSED;
@@ -197,7 +199,9 @@ bool kitty_parse_sequence(int first_char, KittyKeyEvent* event, MEVENT* mouse_ev
         mouse_event->bstate |= BUTTON4_PRESSED;
       }
       else if (base_button == 65) {
+        #ifdef BUTTON5_PRESSED
         mouse_event->bstate |= BUTTON5_PRESSED;
+        #endif
       }
       else if (base_button == 66) {
         mouse_event->bstate |= BUTTON6_PRESSED;

--- a/src/terminal/term_handler.c
+++ b/src/terminal/term_handler.c
@@ -1,32 +1,18 @@
-#include <assert.h>
-#include <libgen.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "../data-management/file_management.h"
-#include "kitty_protocol.h"
 #include "term_handler.h"
 
-#include <limits.h>
-#include <math.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "../core/editor_context.h"
+#include "../data-management/file_management.h"
 #include "../environnement/constants.h"
 #include "highlight.h"
+#include "kitty_protocol.h"
 #include "windows/edw.h"
 #include "windows/few.h"
 #include "windows/ofw.h"
 #include "windows/tpw.h"
-
-/* macOS system ncurses may expose NCURSES_EXT_COLORS internally without
- * declaring init_extended_color/init_extended_pair. Use basic color pairs there.
- */
-#ifdef __APPLE__
-  #define AL_HAS_EXTENDED_NCURSES_COLORS 0
-#else
-  #define AL_HAS_EXTENDED_NCURSES_COLORS 1
-#endif
 
 ////// -------------- WINDOWS MANAGEMENTS --------------
 
@@ -70,8 +56,16 @@ void gui_initNCurses(gui_Context* gui_context) {
     start_color();
     use_default_colors();
 
-    #if AL_HAS_EXTENDED_NCURSES_COLORS
-    // Check if we can change colors. If not, we'll stick to default palette.
+    bool use_extended = false;
+#if AL_HAS_EXTENDED_NCURSES_COLORS
+    if (COLORS >= 256) {
+      use_extended = true;
+    }
+#endif
+
+    if (use_extended) {
+#if AL_HAS_EXTENDED_NCURSES_COLORS
+      // Check if we can change colors. If not, we'll stick to default palette.
       if (can_change_color()) {
         init_extended_color(BG_COLOR_DEFAULT, 50, 50, 50);
         init_extended_color(BG_COLOR_HOVER, 200, 200, 200);
@@ -79,25 +73,24 @@ void gui_initNCurses(gui_Context* gui_context) {
         init_extended_color(COLOR_CYAN, 100, 700, 650);
         init_extended_color(COLOR_TRUE_WHITE, 1000, 1000, 1000);
       }
-  
+
       init_extended_pair(DEFAULT_COLOR_PAIR, COLOR_WHITE, BG_COLOR_DEFAULT);
       init_extended_pair(DEFAULT_COLOR_HOVER_PAIR, COLOR_WHITE, BG_COLOR_HOVER);
-  
+
       init_extended_pair(ERROR_COLOR_PAIR, COLOR_RED, BG_COLOR_POPUP);
       init_extended_pair(ERROR_COLOR_HOVER_PAIR, COLOR_RED, BG_COLOR_HOVER);
-  
+
       init_extended_pair(WARNING_COLOR_PAIR, COLOR_YELLOW, BG_COLOR_POPUP);
       init_extended_pair(WARNING_COLOR_HOVER_PAIR, COLOR_YELLOW, BG_COLOR_HOVER);
-  
+
       init_extended_pair(INFO_COLOR_PAIR, COLOR_CYAN, BG_COLOR_POPUP);
       init_extended_pair(INFO_COLOR_HOVER_PAIR, COLOR_CYAN, BG_COLOR_HOVER);
-  
+
       init_extended_pair(STATUS_BAR_COLOR_PAIR, COLOR_TRUE_WHITE, BG_COLOR_HOVER);
-      
-    #else
-      // TODO: Find a better macOS color fallback.
-      // macOS system ncurses does not expose init_extended_color/init_extended_pair,
-      // so this currently uses basic color pairs and loses theme colors.
+#endif
+    }
+    else {
+      // Fallback
       init_pair(DEFAULT_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
       init_pair(DEFAULT_COLOR_HOVER_PAIR, COLOR_WHITE, COLOR_BLACK);
       init_pair(ERROR_COLOR_PAIR, COLOR_RED, COLOR_BLACK);
@@ -107,7 +100,7 @@ void gui_initNCurses(gui_Context* gui_context) {
       init_pair(INFO_COLOR_PAIR, COLOR_CYAN, COLOR_BLACK);
       init_pair(INFO_COLOR_HOVER_PAIR, COLOR_CYAN, COLOR_BLACK);
       init_pair(STATUS_BAR_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
-    #endif
+    }
   }
 }
 

--- a/src/terminal/term_handler.c
+++ b/src/terminal/term_handler.c
@@ -19,6 +19,14 @@
 #include "windows/ofw.h"
 #include "windows/tpw.h"
 
+/* macOS system ncurses may expose NCURSES_EXT_COLORS internally without
+ * declaring init_extended_color/init_extended_pair. Use basic color pairs there.
+ */
+#ifdef __APPLE__
+  #define AL_HAS_EXTENDED_NCURSES_COLORS 0
+#else
+  #define AL_HAS_EXTENDED_NCURSES_COLORS 1
+#endif
 
 ////// -------------- WINDOWS MANAGEMENTS --------------
 
@@ -62,28 +70,44 @@ void gui_initNCurses(gui_Context* gui_context) {
     start_color();
     use_default_colors();
 
+    #if AL_HAS_EXTENDED_NCURSES_COLORS
     // Check if we can change colors. If not, we'll stick to default palette.
-    if (can_change_color()) {
-      init_extended_color(BG_COLOR_DEFAULT, 50, 50, 50);
-      init_extended_color(BG_COLOR_HOVER, 200, 200, 200);
-      init_extended_color(BG_COLOR_POPUP, 100, 100, 100);
-      init_extended_color(COLOR_CYAN, 100, 700, 650);
-      init_extended_color(COLOR_TRUE_WHITE, 1000, 1000, 1000);
-    }
-
-    init_extended_pair(DEFAULT_COLOR_PAIR, COLOR_WHITE, BG_COLOR_DEFAULT);
-    init_extended_pair(DEFAULT_COLOR_HOVER_PAIR, COLOR_WHITE, BG_COLOR_HOVER);
-
-    init_extended_pair(ERROR_COLOR_PAIR, COLOR_RED, BG_COLOR_POPUP);
-    init_extended_pair(ERROR_COLOR_HOVER_PAIR, COLOR_RED, BG_COLOR_HOVER);
-
-    init_extended_pair(WARNING_COLOR_PAIR, COLOR_YELLOW, BG_COLOR_POPUP);
-    init_extended_pair(WARNING_COLOR_HOVER_PAIR, COLOR_YELLOW, BG_COLOR_HOVER);
-
-    init_extended_pair(INFO_COLOR_PAIR, COLOR_CYAN, BG_COLOR_POPUP);
-    init_extended_pair(INFO_COLOR_HOVER_PAIR, COLOR_CYAN, BG_COLOR_HOVER);
-
-    init_extended_pair(STATUS_BAR_COLOR_PAIR, COLOR_TRUE_WHITE, BG_COLOR_HOVER);
+      if (can_change_color()) {
+        init_extended_color(BG_COLOR_DEFAULT, 50, 50, 50);
+        init_extended_color(BG_COLOR_HOVER, 200, 200, 200);
+        init_extended_color(BG_COLOR_POPUP, 100, 100, 100);
+        init_extended_color(COLOR_CYAN, 100, 700, 650);
+        init_extended_color(COLOR_TRUE_WHITE, 1000, 1000, 1000);
+      }
+  
+      init_extended_pair(DEFAULT_COLOR_PAIR, COLOR_WHITE, BG_COLOR_DEFAULT);
+      init_extended_pair(DEFAULT_COLOR_HOVER_PAIR, COLOR_WHITE, BG_COLOR_HOVER);
+  
+      init_extended_pair(ERROR_COLOR_PAIR, COLOR_RED, BG_COLOR_POPUP);
+      init_extended_pair(ERROR_COLOR_HOVER_PAIR, COLOR_RED, BG_COLOR_HOVER);
+  
+      init_extended_pair(WARNING_COLOR_PAIR, COLOR_YELLOW, BG_COLOR_POPUP);
+      init_extended_pair(WARNING_COLOR_HOVER_PAIR, COLOR_YELLOW, BG_COLOR_HOVER);
+  
+      init_extended_pair(INFO_COLOR_PAIR, COLOR_CYAN, BG_COLOR_POPUP);
+      init_extended_pair(INFO_COLOR_HOVER_PAIR, COLOR_CYAN, BG_COLOR_HOVER);
+  
+      init_extended_pair(STATUS_BAR_COLOR_PAIR, COLOR_TRUE_WHITE, BG_COLOR_HOVER);
+      
+    #else
+      // TODO: Find a better macOS color fallback.
+      // macOS system ncurses does not expose init_extended_color/init_extended_pair,
+      // so this currently uses basic color pairs and loses theme colors.
+      init_pair(DEFAULT_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
+      init_pair(DEFAULT_COLOR_HOVER_PAIR, COLOR_WHITE, COLOR_BLACK);
+      init_pair(ERROR_COLOR_PAIR, COLOR_RED, COLOR_BLACK);
+      init_pair(ERROR_COLOR_HOVER_PAIR, COLOR_RED, COLOR_BLACK);
+      init_pair(WARNING_COLOR_PAIR, COLOR_YELLOW, COLOR_BLACK);
+      init_pair(WARNING_COLOR_HOVER_PAIR, COLOR_YELLOW, COLOR_BLACK);
+      init_pair(INFO_COLOR_PAIR, COLOR_CYAN, COLOR_BLACK);
+      init_pair(INFO_COLOR_HOVER_PAIR, COLOR_CYAN, COLOR_BLACK);
+      init_pair(STATUS_BAR_COLOR_PAIR, COLOR_WHITE, COLOR_BLACK);
+    #endif
   }
 }
 

--- a/src/terminal/term_handler.h
+++ b/src/terminal/term_handler.h
@@ -3,6 +3,14 @@
 #include <ncurses.h>
 #include <wchar.h>
 
+/* Determine if the system's ncurses library supports extended color features (ncurses 6.1+) */
+#if defined(NCURSES_VERSION_MAJOR) &&                                                                                  \
+  (NCURSES_VERSION_MAJOR > 6 || (NCURSES_VERSION_MAJOR == 6 && NCURSES_VERSION_MINOR >= 1))
+#define AL_HAS_EXTENDED_NCURSES_COLORS 1
+#else
+#define AL_HAS_EXTENDED_NCURSES_COLORS 0
+#endif
+
 #include "../data-management/file_management.h"
 #include "../data-management/file_structure.h"
 #include "../io-management/io_explorer.h"
@@ -52,7 +60,6 @@ int getScreenXForCursor(Cursor cursor, int screen_x, int tab_size);
 LineIdentifier getLineIdForScreenX(LineIdentifier line_id, int screen_x, int x_click, int tab_size);
 
 void setDesiredColumn(Cursor cursor, int* desired_column);
-
 
 
 #endif // NCURSES_HANDLER_H

--- a/src/terminal/windows/pow.c
+++ b/src/terminal/windows/pow.c
@@ -413,12 +413,14 @@ bool gui_handleCompletionInput(gui_Context* context, FileContainer* fc, int key,
         gui_updateEDW(context);
       }
     }
-    else if (m_event->bstate & BUTTON5_PRESSED) {
-      if (context->edw_context.item_select_offset_y + height < total_size) {
-        context->edw_context.item_select_offset_y++;
-        gui_updateEDW(context);
+    #ifdef BUTTON5_PRESSED
+      else if (m_event->bstate & BUTTON5_PRESSED) {
+        if (context->edw_context.item_select_offset_y + height < total_size) {
+          context->edw_context.item_select_offset_y++;
+          gui_updateEDW(context);
+        }
       }
-    }
+    #endif
     else if (m_event->bstate & (BUTTON1_PRESSED)) {
       int clicked_item = context->edw_context.item_select_offset_y + (m_event->y - getbegy(context->edw_context.pow));
       if (clicked_item >= 0 && clicked_item < total_size) {
@@ -510,12 +512,14 @@ bool gui_handleGotoChoiceInput(gui_Context* context, FileContainer* fc, int key,
         gui_updateEDW(context);
       }
     }
-    else if (m_event->bstate & BUTTON5_PRESSED) {
-      if (context->edw_context.item_select_offset_y + items_per_page < item_count) {
-        context->edw_context.item_select_offset_y++;
-        gui_updateEDW(context);
+    #ifdef BUTTON5_PRESSED
+      else if (m_event->bstate & BUTTON5_PRESSED) {
+        if (context->edw_context.item_select_offset_y + items_per_page < item_count) {
+          context->edw_context.item_select_offset_y++;
+          gui_updateEDW(context);
+        }
       }
-    }
+    #endif
     else if (m_event->bstate) {
       int clicked_item =
         context->edw_context.item_select_offset_y + (m_event->y - getbegy(context->edw_context.pow) - 1);

--- a/src/terminal/windows/pow.c
+++ b/src/terminal/windows/pow.c
@@ -413,14 +413,14 @@ bool gui_handleCompletionInput(gui_Context* context, FileContainer* fc, int key,
         gui_updateEDW(context);
       }
     }
-    #ifdef BUTTON5_PRESSED
-      else if (m_event->bstate & BUTTON5_PRESSED) {
-        if (context->edw_context.item_select_offset_y + height < total_size) {
-          context->edw_context.item_select_offset_y++;
-          gui_updateEDW(context);
-        }
+#ifdef BUTTON5_PRESSED
+    else if (m_event->bstate & BUTTON5_PRESSED) {
+      if (context->edw_context.item_select_offset_y + height < total_size) {
+        context->edw_context.item_select_offset_y++;
+        gui_updateEDW(context);
       }
-    #endif
+    }
+#endif
     else if (m_event->bstate & (BUTTON1_PRESSED)) {
       int clicked_item = context->edw_context.item_select_offset_y + (m_event->y - getbegy(context->edw_context.pow));
       if (clicked_item >= 0 && clicked_item < total_size) {
@@ -512,14 +512,14 @@ bool gui_handleGotoChoiceInput(gui_Context* context, FileContainer* fc, int key,
         gui_updateEDW(context);
       }
     }
-    #ifdef BUTTON5_PRESSED
-      else if (m_event->bstate & BUTTON5_PRESSED) {
-        if (context->edw_context.item_select_offset_y + items_per_page < item_count) {
-          context->edw_context.item_select_offset_y++;
-          gui_updateEDW(context);
-        }
+#ifdef BUTTON5_PRESSED
+    else if (m_event->bstate & BUTTON5_PRESSED) {
+      if (context->edw_context.item_select_offset_y + items_per_page < item_count) {
+        context->edw_context.item_select_offset_y++;
+        gui_updateEDW(context);
       }
-    #endif
+    }
+#endif
     else if (m_event->bstate) {
       int clicked_item =
         context->edw_context.item_select_offset_y + (m_event->y - getbegy(context->edw_context.pow) - 1);

--- a/src/utils/clipboard_manager.c
+++ b/src/utils/clipboard_manager.c
@@ -1,10 +1,11 @@
 #include "clipboard_manager.h"
 
 #include <ctype.h>
-#include <linux/prctl.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 #include <stdlib.h>
 #include <sys/poll.h>
-#include <sys/prctl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include "../data-management/file_management.h"
@@ -17,6 +18,13 @@ char* xclip_path;
 char* wl_copy_path;
 char* wl_paste_path;
 
+// PR_SET_PDEATHSIG is specific to Linux. Other platforms can still run the
+// clipboard helper without this extra child-process cleanup behavior.
+static void setChildDeathSignal(void) {
+  #ifdef __linux__
+    prctl(PR_SET_PDEATHSIG, SIGTERM);
+  #endif
+}
 
 void createClipBoardTmpDir() { mkdir_p(CLIPBOARD_PATH, 0777); }
 
@@ -99,7 +107,7 @@ bool saveToClipBoard(Cursor begin, Cursor end) {
       dup2(fileno(f_last_clip), STDIN_FILENO);
       fclose(f_last_clip);
 
-      prctl(PR_SET_PDEATHSIG, SIGTERM);
+      setChildDeathSignal();
 
       execl(xclip_path, xclip_path, "-selection", "clipboard", "-in", NULL);
       exit(1);
@@ -116,7 +124,7 @@ bool saveToClipBoard(Cursor begin, Cursor end) {
       dup2(fileno(f_last_clip), STDIN_FILENO);
       fclose(f_last_clip);
 
-      prctl(PR_SET_PDEATHSIG, SIGTERM);
+      setChildDeathSignal();
 
       execl(wl_copy_path, wl_copy_path, NULL);
       exit(1);
@@ -147,7 +155,7 @@ static FILE* openClipboardReader(pid_t* out_child_pid) {
       close(pipe_read[0]);
       close(pipe_read[1]);
 
-      prctl(PR_SET_PDEATHSIG, SIGTERM);
+      setChildDeathSignal();
 
       execl(wl_paste_path, wl_paste_path, "-n", NULL);
       exit(1);
@@ -162,7 +170,7 @@ static FILE* openClipboardReader(pid_t* out_child_pid) {
       close(pipe_read[0]);
       close(pipe_read[1]);
 
-      prctl(PR_SET_PDEATHSIG, SIGTERM);
+      setChildDeathSignal();
 
       execl(xclip_path, xclip_path, "-selection", "clipboard", "-out", NULL);
       exit(1);

--- a/src/utils/tools.c
+++ b/src/utils/tools.c
@@ -7,8 +7,6 @@
 #include <errno.h>
 #include <assert.h>
 #include <ctype.h>
-#include <errno.h>
-#include <limits.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/utils/tools.c
+++ b/src/utils/tools.c
@@ -4,12 +4,12 @@
 #include "../data-management/encoding/utf8.h"
 #include "../data-management/file_management.h"
 
-#include <asm-generic/errno-base.h>
+#include <errno.h>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/utils/tools.h
+++ b/src/utils/tools.h
@@ -1,7 +1,7 @@
 #ifndef TOOLS_H
 #define TOOLS_H
 
-#include <linux/limits.h>
+#include <limits.h>
 #include <ncurses.h>
 #include <stdint.h>
 #include <sys/types.h>


### PR DESCRIPTION
This PR adds some simple fixes required to build on macOS.

Changes:
- Replace Linux-specific <linux/limits.h> with portable <limits.h>
- Replace <asm-generic/errno-base.h> with <errno.h>
- Guard Linux-only prctl(PR_SET_PDEATHSIG, ...) calls
- Guard BUTTON5_* mouse events on ncurses implementations that do not expose them
- Add a fallback for ncurses builds without init_extended_color/init_extended_pair

Known issues:
- Theme colors currently fall back to basic ncurses colors on macOS
- Mouse wheel down is not supported on macOS ncurses and requires a proper workaround

Tested:
- macOS (Apple Silicon, did not test on x86)
- Linux (Ubuntu 24)